### PR TITLE
add a missing subscript(bounds:) setter

### DIFF
--- a/Sources/SE0270_RangeSet/CollectionExtensions.swift
+++ b/Sources/SE0270_RangeSet/CollectionExtensions.swift
@@ -41,7 +41,7 @@ extension MutableCollection {
       DiscontiguousSlice(base: self, subranges: subranges)
     }
     set {
-      for i in newValue.indices {
+      for i in newValue.indices where subranges.contains(i.base) {
         self[i.base] = newValue[i]
       }
     }

--- a/Sources/SE0270_RangeSet/DiscontiguousSlice.swift
+++ b/Sources/SE0270_RangeSet/DiscontiguousSlice.swift
@@ -122,4 +122,19 @@ extension DiscontiguousSlice: MutableCollection where Base: MutableCollection {
       base[i.base] = newValue
     }
   }
+
+  public subscript(bounds: Range<Index>) -> DiscontiguousSlice<Base> {
+    get {
+      let baseBounds = bounds.lowerBound.base ..< bounds.upperBound.base
+      let subset = subranges.intersection(RangeSet(baseBounds))
+      return DiscontiguousSlice<Base>(base: base, subranges: subset)
+    }
+    set {
+      let baseBounds = bounds.lowerBound.base ..< bounds.upperBound.base
+      let subset = subranges.intersection(RangeSet(baseBounds))
+      for i in newValue.indices where subset.contains(i.base) {
+        base[i.base] = newValue[i]
+      }
+    }
+  }
 }

--- a/Tests/SE0270_RangeSet_Tests/CollectionExtensionsTests.swift
+++ b/Tests/SE0270_RangeSet_Tests/CollectionExtensionsTests.swift
@@ -167,11 +167,11 @@ final class CollectionExtensionsTests: XCTestCase {
 
     var mutated = initial
     let set = RangeSet(ranges)
-    mutated[set] = changed[set]
+    let subset = set.intersection(RangeSet(0..<(initial.count/2)))
+    mutated[subset] = changed[set]
 
-    let mutatedElements = ranges.map({ initial[$0] }).joined().map({ 10*$0 })
-    XCTAssert(mutated[set].elementsEqual(mutatedElements))
-    let antiset = RangeSet(initial.indices).subtracting(set)
+    XCTAssert(mutated[subset].elementsEqual(changed[subset]))
+    let antiset = RangeSet(initial.indices).subtracting(subset)
     XCTAssert(mutated[antiset].elementsEqual(initial[antiset]))
   }
 

--- a/Tests/SE0270_RangeSet_Tests/CollectionExtensionsTests.swift
+++ b/Tests/SE0270_RangeSet_Tests/CollectionExtensionsTests.swift
@@ -155,6 +155,46 @@ final class CollectionExtensionsTests: XCTestCase {
     }
   }
   
+  func testDiscontiguousMutableSlicing() {
+    let initial = Array(1...30)
+    let changed = initial.map { 10*$0 }
+
+    let rangeStarts = initial.indices.every(10)
+    let rangeEnds = rangeStarts.compactMap {
+      initial.index($0, offsetBy: 5, limitedBy: initial.endIndex)
+    }
+    let ranges = zip(rangeStarts, rangeEnds).map(Range.init)
+
+    var mutated = initial
+    let set = RangeSet(ranges)
+    mutated[set] = changed[set]
+
+    let mutatedElements = ranges.map({ initial[$0] }).joined().map({ 10*$0 })
+    XCTAssert(mutated[set].elementsEqual(mutatedElements))
+    let antiset = RangeSet(initial.indices).subtracting(set)
+    XCTAssert(mutated[antiset].elementsEqual(initial[antiset]))
+  }
+
+  func testDiscontiguousSliceMutableSlicing() {
+    let initial = Array(1...30)
+    let changed = initial.map { 10*$0 }
+
+    let rangeStarts = initial.indices.every(10)
+    let rangeEnds = rangeStarts.compactMap {
+      initial.index($0, offsetBy: 5, limitedBy: initial.endIndex)
+    }
+    let ranges = zip(rangeStarts, rangeEnds).map(Range.init)
+
+    let set = RangeSet(ranges)
+    let subset = set.intersection(RangeSet(0..<(initial.count/2)))
+    var mutated = initial[subset]
+    let mutations = subset.ranges.map({ initial[$0] }).joined().map({ 10*$0 })
+    mutated[...] = changed[set]
+    XCTAssertLessThan(mutated.count, changed[set].count)
+
+    XCTAssert(mutated.base[subset].elementsEqual(mutations))
+  }
+
   func testNoCopyOnWrite() {
     var numbers = COWLoggingArray(1...20)
     let copyCount = COWLoggingArray_CopyCount


### PR DESCRIPTION
Implement the setter for `DiscontinuousSlice.subscript(bounds:)`.