### PR TITLE
add a precondition to prevent slice assignment out-of-bounds

### DIFF
--- a/Sources/SE0270_RangeSet/CollectionExtensions.swift
+++ b/Sources/SE0270_RangeSet/CollectionExtensions.swift
@@ -41,7 +41,9 @@ extension MutableCollection {
       DiscontiguousSlice(base: self, subranges: subranges)
     }
     set {
-      for i in newValue.indices where subranges.contains(i.base) {
+      for i in newValue.indices {
+        precondition(subranges.contains(i.base),
+                     "index out of range in slice assignment")
         self[i.base] = newValue[i]
       }
     }

--- a/Sources/SE0270_RangeSet/DiscontiguousSlice.swift
+++ b/Sources/SE0270_RangeSet/DiscontiguousSlice.swift
@@ -132,7 +132,9 @@ extension DiscontiguousSlice: MutableCollection where Base: MutableCollection {
     set {
       let baseBounds = bounds.lowerBound.base ..< bounds.upperBound.base
       let subset = subranges.intersection(RangeSet(baseBounds))
-      for i in newValue.indices where subset.contains(i.base) {
+      for i in newValue.indices {
+        precondition(subset.contains(i.base),
+                     "index out of range in slice assignment")
         base[i.base] = newValue[i]
       }
     }


### PR DESCRIPTION
This adds a precondition that will trap if the slice on the right hand side of an assignment contains any index that is absent in the slice on the left hand side of the assignment.