### PR TITLE
Change `insert(:within:)` to return whether the range set was modified

### DIFF
--- a/Tests/SE0270_RangeSet_Tests/RangeSetTests.swift
+++ b/Tests/SE0270_RangeSet_Tests/RangeSetTests.swift
@@ -116,7 +116,54 @@ final class RangeSetTests: XCTestCase {
       XCTAssertEqual(s.ranges, [1..<5, 8..<10, 14..<15, 20..<22, 27..<29])
     }
   }
-  
+
+  func testInsertWithinReturningPreviousContainment() {
+    do {
+      var s = RangeSet<Int>()
+      XCTAssertTrue(s.insert(20, within: parent))
+    }
+    do {
+      var s = source
+      XCTAssertTrue(s.insert(-100, within: parent))
+    }
+    do {
+      var s = source
+      XCTAssertFalse(s.insert(20, within: parent))
+    }
+    do {
+      var s = source
+      XCTAssertFalse(s.insert(21, within: parent))
+    }
+    do {
+      var s = source
+      XCTAssertTrue(s.insert(22, within: parent))
+    }
+    do {
+      var s = source
+      XCTAssertTrue(s.insert(23, within: parent))
+    }
+    do {
+      var s = source
+      XCTAssertTrue(s.insert(26, within: parent))
+    }
+    do {
+      var s = source
+      XCTAssertFalse(s.insert(27, within: parent))
+    }
+    do {
+      var s = source
+      XCTAssertFalse(s.insert(28, within: parent))
+    }
+    do {
+      var s = source
+      XCTAssertTrue(s.insert(29, within: parent))
+    }
+    do {
+      var s = source
+      XCTAssertTrue(s.insert(100, within: parent))
+    }
+  }
+
   func testRemovals() {
     do {
       var s = source


### PR DESCRIPTION
The insert method
```
public mutating func insert<C>(_ index: Bound, within collection: C) -> Bool
```
now returns a `Bool` indicating whether the range set was modified.

The other insert method, `insert(contentsOf:)`, and the modified one now call into an `internal` version:
```
internal mutating func _insert(contentsOf range: Range<Bound>) -> Bool
```

The `public` version of `insert(contentsOf:)` ignores the return value, and `insert(:within:)` returns the result.

## Motivation

Some use cases need to know if the range set was modified, and would previously have to call `contains()` and then `insert()` basically doubling the work to be done — since both have to do a search in the range set.

One example is building a type that conforms to `SetAlgebra` and basing it on `RangeSet`. The `insert()` method needed for `SetAlgebra` needs to know if its value has been mutated.